### PR TITLE
Throw exception on client error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -197,7 +197,7 @@ class Client {
             if ($e->getResponse()->getStatusCode() == 401) {
                 $this->authenticate($clientId, $clientSecret);
             }
-            return null;
+            throw $e;
         }
         catch (GuzzleException $e) {
             throw new ReloadlyException($e->getMessage(), $e->getCode());


### PR DESCRIPTION
Returning null when something goes wrong is not useful.

I need to know what went wrong exactly.